### PR TITLE
- fixed default handlebars partial include style.

### DIFF
--- a/lib/engine_handlebars.js
+++ b/lib/engine_handlebars.js
@@ -29,7 +29,7 @@ var engine_handlebars = {
 
   // partial expansion is only necessary for Mustache templates that have
   // style modifiers or pattern parameters (I think)
-  expandPartials: false,
+  expandPartials: true,
 
   // regexes, stored here so they're only compiled once
   findPartialsRE: /{{#?>\s*([\w-\/.]+)(?:.|\s+)*?}}/g,


### PR DESCRIPTION
for example:
`{{> 00-atoms/my-modue}}` wasn`t work.
But it should:
http://patternlab.io/docs/pattern-including.html
