### PR TITLE
works with recursive parametered-partials functionality

### DIFF
--- a/lib/engine_handlebars.js
+++ b/lib/engine_handlebars.js
@@ -48,9 +48,26 @@ var engine_handlebars = {
     Handlebars.registerPartial(pattern.patternPartial, pattern.template);
   },
 
+  /**
+   * Find regex matches within both pattern strings and pattern objects.
+   *
+   * @param {string|object} pattern Either a string or a pattern object.
+   * @param {object} regex A JavaScript RegExp object.
+   * @returns {array|null} An array if a match is found, null if not.
+   */
+  patternMatcher: function patternMatcher(pattern, regex) {
+    var matches;
+    if (typeof pattern === 'string') {
+      matches = pattern.match(regex);
+    } else if (typeof pattern === 'object' && typeof pattern.extendedTemplate === 'string') {
+      matches = pattern.extendedTemplate.match(regex);
+    }
+    return matches;
+  },
+
   // find and return any {{> template-name }} within pattern
   findPartials: function findPartials(pattern) {
-    var matches = pattern.template.match(this.findPartialsRE);
+    var matches = this.patternMatcher(pattern, this.findPartialsRE);
     return matches;
   },
   findPartialsWithStyleModifiers: function () {
@@ -67,7 +84,7 @@ var engine_handlebars = {
     return [];
   },
   findListItems: function (pattern) {
-    var matches = pattern.template.match(this.findListItemsRE);
+    var matches = this.patternMatcher(pattern, this.findListItemsRE);
     return matches;
   },
 


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses pattern-lab/patternlab-node/issues/250

Summary of changes:
Adding `patternMatcher` method. Searching through `.extendedTemplate` instead of `.template`
