### PR TITLE
Fixed issue with hidden patterns not being able to be included.

### DIFF
--- a/lib/engine_handlebars.js
+++ b/lib/engine_handlebars.js
@@ -45,6 +45,7 @@ var engine_handlebars = {
   },
 
   registerPartial: function (pattern) {
+    pattern.patternPartial = pattern.patternPartial.replace('-_', '-');
     Handlebars.registerPartial(pattern.patternPartial, pattern.template);
   },
 


### PR DESCRIPTION
Summary of changes:

Hidden patterns were registered with an underscore in the name. I changed it to remove the underscore from the pattern name.

I've hidden `patternName` in my project and wanted to include it like:

```
{{> patternType-patternName }}
```

This failed, because in the pattern registry of Handlebars it was registered with an underscore before the pattern name.
